### PR TITLE
실종자 리포트 화면(메인) 기본 UI 구현

### DIFF
--- a/frontend/src/components/common/InputForm.js
+++ b/frontend/src/components/common/InputForm.js
@@ -1,0 +1,32 @@
+import { Form, Input } from "antd";
+import styled from "styled-components";
+
+export const InputForm = ({ label, value }) => {
+  return (
+    <>
+      <InputLabel>{label}</InputLabel>
+      <InputItem>
+        <InputField variant="borderless" value={value} readOnly={"true"} />
+      </InputItem>
+    </>
+  );
+};
+
+/* 각 정보 input 영역 */
+const InputItem = styled(Form.Item)`
+  padding-bottom: 0;
+
+  .ant-form-item .ant-form-item-label {
+    padding-bottom: 0;
+  }
+`;
+
+const InputLabel = styled.span`
+  padding-bottom: 0;
+  color: #00000060;
+  font-size: 0.56rem;
+`;
+
+const InputField = styled(Input)`
+  padding-left: 0rem;
+`;

--- a/frontend/src/components/common/InputForm.js
+++ b/frontend/src/components/common/InputForm.js
@@ -16,26 +16,26 @@ export const InputForm = ({ label, name }) => {
 const StInputForm = styled.div`
   display: flex;
   flex-direction: column;
-  height: 2.4rem;
+  height: 3.9rem;
   margin-bottom: 0.6rem;
 `;
 const InputItem = styled(Form.Item)`
   padding: 0;
   margin: 0;
-  height: 1.375rem;
+  height: 2.2rem;
   min-height: 0rem;
 `;
 
 const InputLabel = styled.span`
   padding-bottom: 0;
   color: #00000060;
-  font-size: 0.56rem;
+  font-size: 1rem;
 `;
 
 const InputField = styled(Input)`
   padding: 0;
   color: black;
-  font-size: 0.875rem;
-  line-height: 1.375rem;
+  font-size: 1.4rem;
+  line-height: 2.2rem;
   margin-bottom: 0.6rem;
 `;

--- a/frontend/src/components/common/InputForm.js
+++ b/frontend/src/components/common/InputForm.js
@@ -1,11 +1,11 @@
 import { Form, Input } from "antd";
 import styled from "styled-components";
 
-export const InputForm = ({ label, value }) => {
+export const InputForm = ({ label, name, value }) => {
   return (
     <>
       <InputLabel>{label}</InputLabel>
-      <InputItem>
+      <InputItem name={name}>
         <InputField variant="borderless" value={value} readOnly={"true"} />
       </InputItem>
     </>

--- a/frontend/src/components/common/InputForm.js
+++ b/frontend/src/components/common/InputForm.js
@@ -1,24 +1,29 @@
 import { Form, Input } from "antd";
 import styled from "styled-components";
 
-export const InputForm = ({ label, name, value }) => {
+export const InputForm = ({ label, name }) => {
   return (
-    <>
+    <StInputForm>
       <InputLabel>{label}</InputLabel>
       <InputItem name={name}>
-        <InputField variant="borderless" value={value} readOnly={"true"} />
+        <InputField variant="borderless" readOnly={"true"} />
       </InputItem>
-    </>
+    </StInputForm>
   );
 };
 
 /* 각 정보 input 영역 */
+const StInputForm = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 2.4rem;
+  margin-bottom: 0.6rem;
+`;
 const InputItem = styled(Form.Item)`
-  padding-bottom: 0;
-
-  .ant-form-item .ant-form-item-label {
-    padding-bottom: 0;
-  }
+  padding: 0;
+  margin: 0;
+  height: 1.375rem;
+  min-height: 0rem;
 `;
 
 const InputLabel = styled.span`
@@ -28,5 +33,9 @@ const InputLabel = styled.span`
 `;
 
 const InputField = styled(Input)`
-  padding-left: 0rem;
+  padding: 0;
+  color: black;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  margin-bottom: 0.6rem;
 `;

--- a/frontend/src/components/common/ResultView.js
+++ b/frontend/src/components/common/ResultView.js
@@ -46,12 +46,7 @@ const StResultView = styled.div`
   bottom: 0;
   padding: 0rem 2rem;
 `;
-const TopContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: end;
-  float: right;
-`;
+
 const MiddleContainer = styled.div`
   display: flex;
   flex-direction: row;

--- a/frontend/src/components/common/ResultView.js
+++ b/frontend/src/components/common/ResultView.js
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+import { Select, Pagination, Skeleton } from "antd";
+
+const data = [
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+  { date: "2024-03-26", time: "17:03:14", accuracy: "0.0000" },
+];
+
+export const ResultView = () => {
+  const Item = ({ item }) => {
+    return (
+      <ItemContainer>
+        <Skeleton.Image active={false} style={{ width: "7.2rem", height: "11.9rem" }} />
+        <p>{item.date}</p>
+        <p>{item.time}</p>
+        <p>정확도:{item.accuracy}</p>
+      </ItemContainer>
+    );
+  };
+  return (
+    <StResultView>
+      <MiddleContainer>
+        {data.map((item, idx) => (
+          <Item key={idx} item={item} />
+        ))}
+      </MiddleContainer>
+      <BottomContainer>
+        <div></div>
+        <Paging size="small" defaultCurrent={1} total={50} />
+      </BottomContainer>
+    </StResultView>
+  );
+};
+const StResultView = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: space-between;
+  gap: 1.5rem;
+
+  width: 100%;
+  height: 100%;
+  bottom: 0;
+  padding: 0rem 2rem;
+`;
+const TopContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+  float: right;
+`;
+const MiddleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  height: 100%;
+`;
+const BottomContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  float: right;
+  width: 100%;
+`;
+
+const ItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p {
+    font-size: 1rem;
+  }
+`;
+
+const Paging = styled(Pagination)`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  float: right;
+`;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -95,7 +95,7 @@ const StBasicInfo = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: start;
-  padding: 1.25rem;
+  padding: 1rem 1.25rem;
   gap: 0.38rem;
 
   width: 22.56rem;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -28,7 +28,7 @@ export const BasicInfo = () => {
         <MissingPersonForm form={form} layout="vertical">
           <Row>
             <Col span={11}>
-              <Skeleton.Image active={false} style={{ width: "8rem", height: "10.8rem" }} />
+              <Skeleton.Image active={false} style={{ width: "13rem", height: "16rem" }} />
             </Col>
             <Col span={13}>
               <InputForm label={"성명"} name={"name"} />
@@ -95,11 +95,11 @@ const StBasicInfo = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: start;
-  padding: 1rem 1.25rem;
-  gap: 0.38rem;
+  padding: 1rem 1.5rem;
+  gap: 0.6rem;
 
-  width: 22.56rem;
-  height: 27.5rem;
+  //width: 36rem;
+  height: 42.8rem;
 
   background-color: white;
 `;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -10,7 +10,7 @@ export const BasicInfo = () => {
         <MissingPersonForm layout="vertical">
           <Skeleton.Image active={false} style={{ width: "8rem", height: "10rem" }} />
           <MissingPersonInfoContainer>
-            <InputForm label={"성명"} value={"홍길동"} />
+            <InputForm label={"성명"} value={"홍길동"} name={"name"} />
           </MissingPersonInfoContainer>
         </MissingPersonForm>
       </InfoContainer>

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -1,0 +1,78 @@
+import { Typography, Image, Skeleton, Form, Input } from "antd";
+import styled from "styled-components";
+
+export const BasicInfo = () => {
+  const InputField = ({ label, value }) => {
+    return (
+      <>
+        <InputLabel>{label}</InputLabel>{" "}
+        <InputItem>
+          <InputTextField variant="borderless" value={value} readOnly={"true"} />
+        </InputItem>
+      </>
+    );
+  };
+  const MissingPersonInfo = () => {
+    return (
+      <InfoContainer>
+        <Typography.Title level={5}>실종자 정보</Typography.Title>
+        <MissingPersonForm layout="vertical">
+          <Skeleton.Image active={false} style={{ width: "8rem", height: "10rem" }} />
+          <MissingPersonInfoContainer>
+            <InputField label={"성명"} value={"홍길동"} />
+          </MissingPersonInfoContainer>
+        </MissingPersonForm>
+      </InfoContainer>
+    );
+  };
+
+  return (
+    <StBasicInfo>
+      <MissingPersonInfo />
+    </StBasicInfo>
+  );
+};
+
+const StBasicInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.25rem;
+
+  width: 22.56rem;
+  height: 27.5rem;
+
+  background-color: white;
+`;
+
+const InfoContainer = styled.div`
+  gap: 0.38rem;
+`;
+
+/* 각 정보 input 영역 */
+const InputItem = styled(Form.Item)`
+  padding-bottom: 0;
+
+  .ant-form-item .ant-form-item-label {
+    padding-bottom: 0;
+  }
+`;
+
+const InputLabel = styled.span`
+  padding-bottom: 0;
+  color: #00000060;
+  font-size: 0.56rem;
+`;
+
+const InputTextField = styled(Input)`
+  padding-left: 0rem;
+`;
+
+// 실종자 정보 영역
+const MissingPersonForm = styled(Form)`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+const MissingPersonInfoContainer = styled.div``;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -1,17 +1,8 @@
 import { Typography, Image, Skeleton, Form, Input } from "antd";
 import styled from "styled-components";
+import { InputForm } from "../common/InputForm";
 
 export const BasicInfo = () => {
-  const InputField = ({ label, value }) => {
-    return (
-      <>
-        <InputLabel>{label}</InputLabel>{" "}
-        <InputItem>
-          <InputTextField variant="borderless" value={value} readOnly={"true"} />
-        </InputItem>
-      </>
-    );
-  };
   const MissingPersonInfo = () => {
     return (
       <InfoContainer>
@@ -19,7 +10,7 @@ export const BasicInfo = () => {
         <MissingPersonForm layout="vertical">
           <Skeleton.Image active={false} style={{ width: "8rem", height: "10rem" }} />
           <MissingPersonInfoContainer>
-            <InputField label={"성명"} value={"홍길동"} />
+            <InputForm label={"성명"} value={"홍길동"} />
           </MissingPersonInfoContainer>
         </MissingPersonForm>
       </InfoContainer>
@@ -47,25 +38,6 @@ const StBasicInfo = styled.div`
 
 const InfoContainer = styled.div`
   gap: 0.38rem;
-`;
-
-/* 각 정보 input 영역 */
-const InputItem = styled(Form.Item)`
-  padding-bottom: 0;
-
-  .ant-form-item .ant-form-item-label {
-    padding-bottom: 0;
-  }
-`;
-
-const InputLabel = styled.span`
-  padding-bottom: 0;
-  color: #00000060;
-  font-size: 0.56rem;
-`;
-
-const InputTextField = styled(Input)`
-  padding-left: 0rem;
 `;
 
 // 실종자 정보 영역

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -26,17 +26,6 @@ export const BasicInfo = () => {
       <InfoContainer>
         <Typography.Title level={5}>실종자 정보</Typography.Title>
         <MissingPersonForm form={form} layout="vertical">
-          {/* <Skeleton.Image active={false} style={{ width: "8rem", height: "10.8rem" }} />
-          <MissingPersonInfoContainer>
-            <InputForm label={"성명"} name={"name"} />
-            <Row gap={"1.38rem"}>
-              <InputForm label={"생년월일"} name={"birth"} />
-              <InputForm label={"성별"} name={"gender"} />
-            </Row>
-            <InputForm label={"실종일시"} name={"missingTime"} />
-            <InputForm label={"실종장소"} name={"missingLocation"} />
-          </MissingPersonInfoContainer> */}
-
           <Row>
             <Col span={11}>
               <Skeleton.Image active={false} style={{ width: "8rem", height: "10.8rem" }} />
@@ -66,12 +55,7 @@ export const BasicInfo = () => {
       <InfoContainer>
         <Typography.Title level={5}>보호자 정보</Typography.Title>
         <InfoForm form={form} layout="vertical">
-          {/* <Row gap={"1.19rem"}>
-            <InputForm label={"보호자명"} name={"guardianName"} />
-            <InputForm label={"관계"} name={"relation"} />
-            <InputForm label={"보호자 연락처"} name={"guardianContact"} />
-          </Row> */}
-          <Row guther={"1.2rem"}>
+          <Row>
             <Col span={7}>
               <InputForm label={"보호자명"} name={"guardianName"} />
             </Col>
@@ -87,10 +71,22 @@ export const BasicInfo = () => {
     );
   };
 
+  /* 착장정보 영역 */
+  const WearingInfo = () => {
+    return (
+      <InfoContainer>
+        <Typography.Title level={5}>착장 정보</Typography.Title>
+        <InfoForm form={form} layout="vertical">
+          <Skeleton title={false} />
+        </InfoForm>
+      </InfoContainer>
+    );
+  };
   return (
     <StBasicInfo>
       <MissingPersonInfo />
       <GuardianInfo />
+      <WearingInfo />
     </StBasicInfo>
   );
 };
@@ -100,6 +96,7 @@ const StBasicInfo = styled.div`
   flex-direction: column;
   justify-content: start;
   padding: 1.25rem;
+  gap: 0.38rem;
 
   width: 22.56rem;
   height: 27.5rem;
@@ -107,30 +104,11 @@ const StBasicInfo = styled.div`
   background-color: white;
 `;
 
-const InfoContainer = styled.div`
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-`;
-// const Row = styled.div`
-//   display: flex;
-//   flex-direction: row;
-//   gap: ${(props) => props.gap};
-// `;
+const InfoContainer = styled.div``;
 
 const InfoForm = styled(Form)`
   display: flex;
 `;
 
 // 실종자 정보 영역
-const MissingPersonForm = styled(Form)`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1.25rem;
-`;
-// const MissingPersonInfoContainer = styled.div`
-//   display: flex;
-//   flex-direction: column;
-//   gap: 0.38rem;
-// `;
+const MissingPersonForm = styled(Form)``;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -1,18 +1,88 @@
-import { Typography, Image, Skeleton, Form, Input } from "antd";
+import { Typography, Image, Skeleton, Form, Input, Row, Col } from "antd";
 import styled from "styled-components";
 import { InputForm } from "../common/InputForm";
+import { useEffect } from "react";
 
 export const BasicInfo = () => {
+  const [form] = Form.useForm();
+
+  // 실종자 정보 적용
+  useEffect(() => {
+    form.setFieldsValue({
+      name: "홍길동",
+      birth: "1999.01.01",
+      gender: "남성",
+      missingTime: "2021.08.01 12:00" + "경",
+      missingLocation: "서울시 강남구",
+      guardianName: "김영희",
+      relation: "부",
+      guardianContact: "010-1234-5678",
+    });
+  }, []);
+
+  /* 실종자 정보 영역 */
   const MissingPersonInfo = () => {
     return (
       <InfoContainer>
         <Typography.Title level={5}>실종자 정보</Typography.Title>
-        <MissingPersonForm layout="vertical">
-          <Skeleton.Image active={false} style={{ width: "8rem", height: "10rem" }} />
+        <MissingPersonForm form={form} layout="vertical">
+          {/* <Skeleton.Image active={false} style={{ width: "8rem", height: "10.8rem" }} />
           <MissingPersonInfoContainer>
-            <InputForm label={"성명"} value={"홍길동"} name={"name"} />
-          </MissingPersonInfoContainer>
+            <InputForm label={"성명"} name={"name"} />
+            <Row gap={"1.38rem"}>
+              <InputForm label={"생년월일"} name={"birth"} />
+              <InputForm label={"성별"} name={"gender"} />
+            </Row>
+            <InputForm label={"실종일시"} name={"missingTime"} />
+            <InputForm label={"실종장소"} name={"missingLocation"} />
+          </MissingPersonInfoContainer> */}
+
+          <Row>
+            <Col span={11}>
+              <Skeleton.Image active={false} style={{ width: "8rem", height: "10.8rem" }} />
+            </Col>
+            <Col span={13}>
+              <InputForm label={"성명"} name={"name"} />
+              <Row>
+                <Col span={16}>
+                  <InputForm label={"생년월일"} name={"birth"} />
+                </Col>
+                <Col span={8}>
+                  <InputForm label={"성별"} name={"gender"} />
+                </Col>
+              </Row>
+              <InputForm label={"실종일시"} name={"missingTime"} />
+              <InputForm label={"실종장소"} name={"missingLocation"} />
+            </Col>
+          </Row>
         </MissingPersonForm>
+      </InfoContainer>
+    );
+  };
+
+  /* 실종자 정보 영역 */
+  const GuardianInfo = () => {
+    return (
+      <InfoContainer>
+        <Typography.Title level={5}>보호자 정보</Typography.Title>
+        <InfoForm form={form} layout="vertical">
+          {/* <Row gap={"1.19rem"}>
+            <InputForm label={"보호자명"} name={"guardianName"} />
+            <InputForm label={"관계"} name={"relation"} />
+            <InputForm label={"보호자 연락처"} name={"guardianContact"} />
+          </Row> */}
+          <Row guther={"1.2rem"}>
+            <Col span={7}>
+              <InputForm label={"보호자명"} name={"guardianName"} />
+            </Col>
+            <Col span={4}>
+              <InputForm label={"관계"} name={"relation"} />
+            </Col>
+            <Col span={13}>
+              <InputForm label={"보호자 연락처"} name={"guardianContact"} />
+            </Col>
+          </Row>
+        </InfoForm>
       </InfoContainer>
     );
   };
@@ -20,6 +90,7 @@ export const BasicInfo = () => {
   return (
     <StBasicInfo>
       <MissingPersonInfo />
+      <GuardianInfo />
     </StBasicInfo>
   );
 };
@@ -27,7 +98,7 @@ export const BasicInfo = () => {
 const StBasicInfo = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
   padding: 1.25rem;
 
   width: 22.56rem;
@@ -38,6 +109,16 @@ const StBasicInfo = styled.div`
 
 const InfoContainer = styled.div`
   gap: 0.38rem;
+  margin-bottom: 1rem;
+`;
+// const Row = styled.div`
+//   display: flex;
+//   flex-direction: row;
+//   gap: ${(props) => props.gap};
+// `;
+
+const InfoForm = styled(Form)`
+  display: flex;
 `;
 
 // 실종자 정보 영역
@@ -46,5 +127,10 @@ const MissingPersonForm = styled(Form)`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  gap: 1.25rem;
 `;
-const MissingPersonInfoContainer = styled.div``;
+const MissingPersonInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+`;

--- a/frontend/src/components/missingPersonReport/BasicInfo.js
+++ b/frontend/src/components/missingPersonReport/BasicInfo.js
@@ -60,7 +60,7 @@ export const BasicInfo = () => {
     );
   };
 
-  /* 실종자 정보 영역 */
+  /* 보호자 정보 영역 */
   const GuardianInfo = () => {
     return (
       <InfoContainer>
@@ -108,7 +108,7 @@ const StBasicInfo = styled.div`
 `;
 
 const InfoContainer = styled.div`
-  gap: 0.38rem;
+  gap: 0.5rem;
   margin-bottom: 1rem;
 `;
 // const Row = styled.div`
@@ -129,8 +129,8 @@ const MissingPersonForm = styled(Form)`
   align-items: center;
   gap: 1.25rem;
 `;
-const MissingPersonInfoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.38rem;
-`;
+// const MissingPersonInfoContainer = styled.div`
+//   display: flex;
+//   flex-direction: column;
+//   gap: 0.38rem;
+// `;

--- a/frontend/src/components/missingPersonReport/ReportList.js
+++ b/frontend/src/components/missingPersonReport/ReportList.js
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import { Typography, List, Skeleton } from "antd";
+import { FileSearchOutlined } from "@ant-design/icons";
+
+const data = ["2024-03-26 10:03:12", "2024-03-26 10:03:12", "2024-03-26 10:03:12", "2024-03-26 10:03:12"];
+
+export const ReportList = () => {
+  return (
+    <StReportList>
+      <Typography.Title level={5}>지능형 탐색 결과</Typography.Title>
+      <ListContainer>
+        <List
+          size="small"
+          itemLayout="horizontal"
+          dataSource={data}
+          renderItem={(item) => (
+            <List.Item actions={[<a key="list-loadmore-more">more</a>]}>
+              <Skeleton avatar title={false} loading={item.loading} active>
+                <List.Item.Meta avatar={<FileSearchOutlined />} description={item} />
+              </Skeleton>
+            </List.Item>
+          )}
+        />
+      </ListContainer>
+    </StReportList>
+  );
+};
+
+const StReportList = styled.div`
+  width: 22.56rem;
+
+  padding: 0.68rem 0.94rem;
+  gap: 0.62rem;
+  background-color: white;
+`;
+
+const ListContainer = styled.div`
+  overflow: "auto";
+`;

--- a/frontend/src/components/missingPersonReport/ReportList.js
+++ b/frontend/src/components/missingPersonReport/ReportList.js
@@ -2,7 +2,13 @@ import styled from "styled-components";
 import { Typography, List, Skeleton } from "antd";
 import { FileSearchOutlined } from "@ant-design/icons";
 
-const data = ["2024-03-26 10:03:12", "2024-03-26 10:03:12", "2024-03-26 10:03:12", "2024-03-26 10:03:12"];
+const data = [
+  "2024-03-26 10:03:12",
+  "2024-03-26 10:03:12",
+  "2024-03-26 10:03:12",
+  "2024-03-26 10:03:12",
+  "2024-03-26 10:03:12",
+];
 
 export const ReportList = () => {
   return (
@@ -14,11 +20,11 @@ export const ReportList = () => {
           itemLayout="horizontal"
           dataSource={data}
           renderItem={(item) => (
-            <List.Item actions={[<a key="list-loadmore-more">more</a>]}>
+            <ListItem actions={[<a key="list-loadmore-more">view</a>]}>
               <Skeleton avatar title={false} loading={item.loading} active>
                 <List.Item.Meta avatar={<FileSearchOutlined />} description={item} />
               </Skeleton>
-            </List.Item>
+            </ListItem>
           )}
         />
       </ListContainer>
@@ -27,13 +33,32 @@ export const ReportList = () => {
 };
 
 const StReportList = styled.div`
-  width: 22.56rem;
-
-  padding: 0.68rem 0.94rem;
+  //width: 36rem;
+  width: 100%;
+  height: 21rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  padding: 1rem 1.5rem;
   gap: 0.62rem;
+  border-radius: 0.3rem;
   background-color: white;
 `;
 
 const ListContainer = styled.div`
-  overflow: "auto";
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  overflow: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const ListItem = styled(List.Item)`
+  width: 32.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  gap: 0.5rem;
 `;

--- a/frontend/src/components/missingPersonReport/ReportList.js
+++ b/frontend/src/components/missingPersonReport/ReportList.js
@@ -1,32 +1,38 @@
 import styled from "styled-components";
-import { Typography, List, Skeleton } from "antd";
+import { Typography, List, Skeleton, Flex, Row, Col } from "antd";
 import { FileSearchOutlined } from "@ant-design/icons";
 
 const data = [
   "2024-03-26 10:03:12",
-  "2024-03-26 10:03:12",
-  "2024-03-26 10:03:12",
-  "2024-03-26 10:03:12",
-  "2024-03-26 10:03:12",
+  "2024-03-24 10:03:12",
+  "2024-03-22 10:03:12",
+  "2024-03-20 10:03:12",
+  "2024-03-14 10:03:12",
 ];
 
 export const ReportList = () => {
+  const ListItems = ({ item }) => {
+    return (
+      <ListItemContainer>
+        <Row gutter={8} justify="space-around">
+          <Col span={2}>
+            <FileSearchOutlined />
+          </Col>
+          <Col span={19}>
+            <p>{item}</p>
+          </Col>
+          <Col span={3}>
+            <a>view</a>
+          </Col>
+        </Row>
+      </ListItemContainer>
+    );
+  };
   return (
     <StReportList>
       <Typography.Title level={5}>지능형 탐색 결과</Typography.Title>
       <ListContainer>
-        <List
-          size="small"
-          itemLayout="horizontal"
-          dataSource={data}
-          renderItem={(item) => (
-            <ListItem actions={[<a key="list-loadmore-more">view</a>]}>
-              <Skeleton avatar title={false} loading={item.loading} active>
-                <List.Item.Meta avatar={<FileSearchOutlined />} description={item} />
-              </Skeleton>
-            </ListItem>
-          )}
-        />
+        <List size="small" itemLayout="horizontal" dataSource={data} renderItem={(item) => <ListItems item={item} />} />
       </ListContainer>
     </StReportList>
   );
@@ -39,26 +45,18 @@ const StReportList = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: start;
-  padding: 1rem 1.5rem;
+  padding: 1.2rem 1.5rem;
   gap: 0.62rem;
   border-radius: 0.3rem;
   background-color: white;
 `;
 
 const ListContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
   overflow: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
 `;
 
-const ListItem = styled(List.Item)`
-  width: 32.5rem;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  align-items: center;
-  gap: 0.5rem;
+const ListItemContainer = styled.div`
+  padding: 1rem 0.5rem;
 `;

--- a/frontend/src/components/missingPersonReport/ReportMap.js
+++ b/frontend/src/components/missingPersonReport/ReportMap.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+export const ReportMap = () => {
+  return (
+    <StReportMap>
+      <Map center={{ lat: 37.610826, lng: 126.994317 }} style={{ width: "100%", height: "27.5rem" }}></Map>
+    </StReportMap>
+  );
+};
+
+const StReportMap = styled.div``;

--- a/frontend/src/components/missingPersonReport/ReportMap.js
+++ b/frontend/src/components/missingPersonReport/ReportMap.js
@@ -3,7 +3,7 @@ import { Map, MapMarker } from "react-kakao-maps-sdk";
 export const ReportMap = () => {
   return (
     <StReportMap>
-      <Map center={{ lat: 37.610826, lng: 126.994317 }} style={{ width: "100%", height: "27.5rem" }}></Map>
+      <Map center={{ lat: 37.610826, lng: 126.994317 }} style={{ width: "100%", height: "43rem" }}></Map>
     </StReportMap>
   );
 };

--- a/frontend/src/components/missingPersonReport/ReportTabs.js
+++ b/frontend/src/components/missingPersonReport/ReportTabs.js
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { Tabs } from "antd";
+
+const items = [
+  {
+    key: "1",
+    label: "1차 탐색",
+    children: "Content of Tab Pane 1",
+  },
+  {
+    key: "2",
+    label: "이미지 선별",
+    children: "Content of Tab Pane 2",
+  },
+  {
+    key: "3",
+    label: "2차 탐색",
+    children: "Content of Tab Pane 3",
+  },
+];
+export const ReportTabs = () => {
+  return (
+    <StReportTabs>
+      <Tabs defaultActiveKey="1" items={items} />
+    </StReportTabs>
+  );
+};
+
+const StReportTabs = styled.div`
+  height: 17.25rem;
+  padding: 0.5rem;
+  background-color: white;
+`;

--- a/frontend/src/components/missingPersonReport/ReportTabs.js
+++ b/frontend/src/components/missingPersonReport/ReportTabs.js
@@ -27,7 +27,8 @@ export const ReportTabs = () => {
 };
 
 const StReportTabs = styled.div`
-  height: 17.25rem;
+  height: 27.6rem;
   padding: 0.5rem;
   background-color: white;
+  border-radius: 0.3rem;
 `;

--- a/frontend/src/components/missingPersonReport/ReportTabs.js
+++ b/frontend/src/components/missingPersonReport/ReportTabs.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
-import { Tabs } from "antd";
+import { Tabs, Select } from "antd";
+import { ReportList } from "./ReportList";
+import { ResultView } from "../common/ResultView";
 
 const items = [
   {
@@ -15,20 +17,51 @@ const items = [
   {
     key: "3",
     label: "2차 탐색",
-    children: "Content of Tab Pane 3",
+    children: <ResultView />,
   },
 ];
+const operations = (
+  <Select
+    defaultValue="정확도순"
+    size="small"
+    style={{
+      width: 120,
+    }}
+    options={[
+      {
+        value: "정확도순",
+        label: "정확도순",
+      },
+      {
+        value: "최근순",
+        label: "최근순",
+      },
+      {
+        value: "오래된순",
+        label: "오래된순",
+      },
+    ]}
+  />
+);
 export const ReportTabs = () => {
   return (
     <StReportTabs>
-      <Tabs defaultActiveKey="1" items={items} />
+      <TabContainer defaultActiveKey="1" items={items} size="small" tabBarExtraContent={operations} />
     </StReportTabs>
   );
 };
 
 const StReportTabs = styled.div`
-  height: 27.6rem;
-  padding: 0.5rem;
+  height: 100%;
+  padding: 0rem 0.5rem;
   background-color: white;
   border-radius: 0.3rem;
+`;
+
+const TabContainer = styled(Tabs)`
+  height: 100%;
+
+  & .ant-tabs {
+    height: 100%;
+  }
 `;

--- a/frontend/src/components/missingPersonReport/StepProgress.js
+++ b/frontend/src/components/missingPersonReport/StepProgress.js
@@ -45,10 +45,11 @@ export const StepProgress = () => {
 };
 
 const StStepProgress = styled.div`
-  height: 27.5rem;
+  height: 43rem;
 
   padding: 1rem 0.63rem;
 
   gap: 1.25rem;
+  border-radius: 0.3rem;
   background-color: white;
 `;

--- a/frontend/src/components/missingPersonReport/StepProgress.js
+++ b/frontend/src/components/missingPersonReport/StepProgress.js
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { Steps, Typography } from "antd";
+
+export const StepProgress = () => {
+  const [current, setCurrent] = useState(0);
+  const description = "This is a description.";
+  const onChange = (value) => {
+    console.log("onChange:", value);
+    setCurrent(value);
+  };
+  return (
+    <StStepProgress>
+      <Typography.Title level={5}>현황</Typography.Title>
+      <Steps
+        direction="vertical"
+        current={current}
+        onChange={onChange}
+        items={[
+          {
+            title: "정보 등록",
+          },
+          {
+            title: "1차 탐색",
+            description,
+          },
+          {
+            title: "이미지 선별",
+            description,
+          },
+          {
+            title: "2차 탐색",
+            description,
+          },
+          {
+            title: "수색",
+            description,
+          },
+          {
+            title: "종료",
+          },
+        ]}></Steps>
+    </StStepProgress>
+  );
+};
+
+const StStepProgress = styled.div`
+  height: 27.5rem;
+
+  padding: 1rem 0.63rem;
+
+  gap: 1.25rem;
+  background-color: white;
+`;

--- a/frontend/src/components/missingPersonReport/StepProgress.js
+++ b/frontend/src/components/missingPersonReport/StepProgress.js
@@ -45,11 +45,13 @@ export const StepProgress = () => {
 };
 
 const StStepProgress = styled.div`
+  display: flex;
+  flex-direction: column;
   height: 43rem;
 
-  padding: 1rem 0.63rem;
+  padding: 1rem;
 
-  gap: 1.25rem;
+  gap: 1.5rem;
   border-radius: 0.3rem;
   background-color: white;
 `;

--- a/frontend/src/core/router.js
+++ b/frontend/src/core/router.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Nav from "../components/common/Nav";
 import Test, { Test2 } from "../pages/test";
 import AddMissingPersonPage from "../pages/AddMissingPersonPage";
+import MissingPersonReportPage from "../pages/MissingPersonReportPage";
 
 function Router() {
   return (
@@ -11,6 +12,7 @@ function Router() {
           <Route path="/" element={<Test />} />
           <Route path="/a" element={<Test2 />} />
           <Route path="/add" element={<AddMissingPersonPage />} />
+          <Route path="/report" element={<MissingPersonReportPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -33,7 +33,7 @@ function MissingPersonReportPage() {
           <StepProgress />
         </Col>
       </Row>
-      <Row>
+      <Row gutter={8}>
         <Col span={6}>
           <Row style={{ marginBottom: 8 }}>
             <ReportList />
@@ -61,8 +61,8 @@ const StReportStartBtn = styled.div`
   justify-content: space-between;
   align-items: center;
 
-  width: 22.56rem;
-  height: 3.25rem;
+  width: 100%;
+  height: 5.2rem;
   padding: 0rem 0.94rem;
   border-radius: 0.3rem;
   background-color: #f0f3ff;
@@ -75,7 +75,7 @@ const ReportStartBtnLeft = styled.div`
   gap: 0.5rem;
 
   p {
-    font-size: 1rem;
+    font-size: 1.5rem;
     font-weight: 600;
   }
 `;

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -22,7 +22,7 @@ function MissingPersonReportPage() {
   };
   return (
     <StMissingPersonReportPage>
-      <Row style={{ marginBottom: 8 }} gutter={8}>
+      <Row gutter={[8, 10]}>
         <Col span={6}>
           <BasicInfo />
         </Col>
@@ -32,8 +32,19 @@ function MissingPersonReportPage() {
         <Col span={4}>
           <StepProgress />
         </Col>
+        <Col span={6} md={6}>
+          <Row style={{ marginBottom: 8 }}>
+            <ReportList />
+          </Row>
+          <Row>
+            <ReportStartBtn />
+          </Row>
+        </Col>
+        <Col span={18} md={18}>
+          <ReportTabs />
+        </Col>
       </Row>
-      <Row gutter={8}>
+      {/* <Row gutter={8}>
         <Col span={6}>
           <Row style={{ marginBottom: 8 }}>
             <ReportList />
@@ -45,7 +56,7 @@ function MissingPersonReportPage() {
         <Col span={18}>
           <ReportTabs />
         </Col>
-      </Row>
+      </Row> */}
     </StMissingPersonReportPage>
   );
 }

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import { BasicInfo } from "../components/missingPersonReport/BasicInfo";
+
+function MissingPersonReportPage() {
+  return (
+    <StMissingPersonReportPage>
+      <BasicInfo />
+    </StMissingPersonReportPage>
+  );
+}
+export default MissingPersonReportPage;
+
+const StMissingPersonReportPage = styled.div``;

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -1,13 +1,81 @@
 import styled from "styled-components";
+import { Row, Col, Typography } from "antd";
+import { ReconciliationOutlined } from "@ant-design/icons";
+
 import { BasicInfo } from "../components/missingPersonReport/BasicInfo";
+import { StepProgress } from "../components/missingPersonReport/StepProgress";
+import { ReportList } from "../components/missingPersonReport/ReportList";
+import { ReportMap } from "../components/missingPersonReport/ReportMap";
+import { ReportTabs } from "../components/missingPersonReport/ReportTabs";
 
 function MissingPersonReportPage() {
+  const ReportStartBtn = () => {
+    return (
+      <StReportStartBtn>
+        <ReportStartBtnLeft>
+          <ReconciliationOutlined style={{ fontSize: "2rem", color: "#1890FF" }} />
+          <p>지능형 탐색</p>
+        </ReportStartBtnLeft>
+        <a> 시작하기</a>
+      </StReportStartBtn>
+    );
+  };
   return (
     <StMissingPersonReportPage>
-      <BasicInfo />
+      <Row style={{ marginBottom: 8 }} gutter={8}>
+        <Col span={6}>
+          <BasicInfo />
+        </Col>
+        <Col span={14}>
+          <ReportMap />
+        </Col>
+        <Col span={4}>
+          <StepProgress />
+        </Col>
+      </Row>
+      <Row>
+        <Col span={6}>
+          <Row style={{ marginBottom: 8 }}>
+            <ReportList />
+          </Row>
+          <Row>
+            <ReportStartBtn />
+          </Row>
+        </Col>
+        <Col span={18}>
+          <ReportTabs />
+        </Col>
+      </Row>
     </StMissingPersonReportPage>
   );
 }
 export default MissingPersonReportPage;
 
-const StMissingPersonReportPage = styled.div``;
+const StMissingPersonReportPage = styled.div`
+  padding: 1rem 1rem;
+  gap: 1rem;
+`;
+const StReportStartBtn = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 22.56rem;
+  height: 3.25rem;
+  padding: 0rem 0.94rem;
+  border-radius: 0.3rem;
+  background-color: #f0f3ff;
+`;
+
+const ReportStartBtnLeft = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+
+  p {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+`;

--- a/frontend/src/styles/global.js
+++ b/frontend/src/styles/global.js
@@ -3,7 +3,10 @@ import { reset } from "styled-reset";
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
-
+  html { font-size: 62.5%; }
+  @media all and (max-width: 750px) {
+  html { font-size: 50%; } // 이제 문서 내 모든 rem 단위가 영향을 받습니다.
+}
 
   * {
     box-sizing: border-box;


### PR DESCRIPTION
## Describe changes

- 실종자 리포트 화면(메인) 기본 UI 구현했습니다.
- 반응형을 위해 grid layout을 사용했습니다.
- 추후 각 기기에서의 화면 모습 확인하여 반응형 수정할 예정입니다.

## Issue number or link

- close #62

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (changes that resolve errors)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Further comments
![ReactApp-Chrome2024-04-1211-26-02-ezgif com-crop](https://github.com/kookmin-sw/capstone-2024-14/assets/84322890/ac5d1004-ceb8-49ee-96be-7a8307971302)

- 반응형 적용되어 nav bar 크기 조절에 따라 각 요소의 너비도 조절되는 모습 확인 가능합니다.
- font-size 및 탐색 이미지 size의 경우 기기 테스트를 통해 수정할 필요가 있을 것 같습니다.
