### PR TITLE
Chore: get image path by user input

### DIFF
--- a/ai/TextReID/lib/config/paths_catalog.py
+++ b/ai/TextReID/lib/config/paths_catalog.py
@@ -2,30 +2,32 @@ import os
 
 
 class DatasetCatalog:
-    DATA_DIR = "datasets"
+    DATA_DIR = ""
     DATASETS = {
         "cuhkpedes_train": {
             "img_dir": "",
-            "ann_file": "annotations/annotations.json",
+            "ann_file": "annotations.json",
         },
         "cuhkpedes_val": {
             "img_dir": "",
-            "ann_file": "annotations/annotations.json",
+            "ann_file": "annotations.json",
         },
         "cuhkpedes_test": {
             "img_dir": "",
-            "ann_file": "annotations/annotations.json",
+            "ann_file": "annotations.json",
         },
     }
 
     @staticmethod
     def get(root, name):
         if "cuhkpedes" in name:
-            data_dir = DatasetCatalog.DATA_DIR
+            # data_dir = DatasetCatalog.DATA_DIR
+            data_dir = input("Input Dataset Directory: ")
+            annotation_dir = input("Input Annotation Directory: ")
             attrs = DatasetCatalog.DATASETS[name]
             args = dict(
                 root=os.path.join(root, data_dir, attrs["img_dir"]),
-                ann_file=os.path.join(root, data_dir, attrs["ann_file"]),
+                ann_file=os.path.join(root, annotation_dir, attrs["ann_file"]),
             )
             return dict(
                 factory="CUHKPEDESDataset",

--- a/ai/TextReID/lib/data/datasets/cuhkpedes.py
+++ b/ai/TextReID/lib/data/datasets/cuhkpedes.py
@@ -12,7 +12,7 @@ class CUHKPEDESDataset(torch.utils.data.Dataset):
         self,
         root,
         ann_file,
-        use_onehot=True, # 여기를 false로 바꾸거나
+        use_onehot=True,
         max_length=100,
         transforms=None,
     ):
@@ -21,7 +21,8 @@ class CUHKPEDESDataset(torch.utils.data.Dataset):
         self.max_length = max_length
         self.transforms = transforms
 
-        self.img_dir = os.path.join(self.root, "imgs")
+        # self.img_dir = os.path.join(self.root, "imgs")
+        self.img_dir = self.root
 
         print("loading annotations into memory...")
         dataset = json.load(open(ann_file, "r"))


### PR DESCRIPTION
## Describe changes

- 이미지 경로를 user input을 통해 받아올 수 있도록 수정

## Issue number or link

- close #98 

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (changes that resolve errors)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Further comments

- 이미지 경로/annotation 경로를 따로 받아오는 구조
- 폴더명까지만 상대경로로 입력
- 이미지에 대응되는 annotation 생성 시 파일명은 `annotation.json`으로 통일
- 이하 적용 예시
  - Input Dataset Directory: `datasets/imgs`
    - 이미지 경로는 `./datasets/imgs/(annotation.json에서 읽어온 경로)`로 load됨
  - Input Annotation Directory: `datasets/annotations`
    - annotation 경로는 `./datasets/annotations/annotation.json`로 load됨