### PR TITLE
Fix: image name from add twice extension to add once extension

### DIFF
--- a/server/src/main/java/com/capstone/server/dto/S3DownloadResponseDto.java
+++ b/server/src/main/java/com/capstone/server/dto/S3DownloadResponseDto.java
@@ -14,13 +14,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class S3DownloadResponseDto {
-    private String path;
     private String url;
+    private String path;
     private Long size;
     // TODO : 필요한 정보 추가
 
     private S3DownloadResponseDto(S3ObjectSummary summary) {
-        this.path = summary.getKey();
+        this.url = summary.getKey();
         this.size = summary.getSize();
     }
 

--- a/server/src/main/java/com/capstone/server/dto/S3UploadResponseDto.java
+++ b/server/src/main/java/com/capstone/server/dto/S3UploadResponseDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class S3UploadResponseDto {
-    private String path;
     private String url;
+    private String path;
     // TODO : 필요한 정보 추가
 }

--- a/server/src/main/java/com/capstone/server/service/S3Service.java
+++ b/server/src/main/java/com/capstone/server/service/S3Service.java
@@ -65,7 +65,9 @@ public class S3Service {
         for (int i = 0; i < images.size(); i++) {
             MultipartFile image = images.get(i);
             String index = String.format("%03d", i+1); // 3자리로 패딩된 숫자 포맷
-            String imageName = imagePath + index + "-" + image.getOriginalFilename();
+            String originalFileName = image.getOriginalFilename();
+            String imageNameWithoutExtension = originalFileName.substring(0, originalFileName.lastIndexOf('.'));
+            String imageName = imagePath + index + "-" + imageNameWithoutExtension;
             s3UploadResponseDtos.add(upload(image, imageName));
         }
 


### PR DESCRIPTION
## Describe changes

_Describe a summary of the changes and the related issue to communicate to the maintainers why we should accept this pull request._
- [x] 이미지 리스트 업로드 시, file original name 을 가져오는 과정에서 extension 은 제외한다.
- [x] path, url 이 반대로 정보가 들어가서 수정하였다.  
- [x] S3 를 캡스톤 계정 버킷으로 변경, properties 업데이트하였다.
## Issue number or link

- close #101 

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [x] Bugfix (changes that resolve errors)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [x] Documentation Update

## Further comments

_Please let me know if there's anything else to explain_
[Notion BE AWS 페이지](https://www.notion.so/AWS-2627c917fd594ca5933d7f0b78b10987?pvs=4) S3 정보 업로드, [Notion BE properties](https://www.notion.so/application-properties-96efe72075fe4b2e977ef53ac960ebc1?pvs=4) 업데이트