### PR TITLE
Feat : 실종자 리포트 스크롤 기능 구현

### DIFF
--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -97,7 +97,7 @@ const StMissingPersonReportPage = styled.div`
   -ms-overflow-style: none;
   scrollbar-width: none;
   scroll-snap-type: y mandatory;
-  behavior: smooth;
+  scroll-behavior: smooth;
 `;
 const StReportStartBtn = styled.div`
   display: flex;

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -12,9 +12,19 @@ import { IntelligentMap } from "../components/reportIntelligent/IntelligentMap";
 import { IntelligentSearchResult } from "../components/reportIntelligent/IntelligentSearchResult";
 
 function MissingPersonReportPage() {
+  /*지능형 탐색 시작하기 스크롤 이벤트 */
+  const scrollToIntelligent = () => {
+    const element = document.getElementById("intelligent");
+    if (element) {
+      element.scrollIntoView({
+        behavior: "smooth",
+      });
+    }
+  };
+  /*지능형 탐색 시작하기 버튼 */
   const ReportStartBtn = () => {
     return (
-      <StReportStartBtn>
+      <StReportStartBtn onClick={scrollToIntelligent}>
         <ReportStartBtnLeft>
           <ReconciliationOutlined style={{ fontSize: "2rem", color: "#1890FF" }} />
           <p>지능형 탐색</p>
@@ -23,6 +33,7 @@ function MissingPersonReportPage() {
       </StReportStartBtn>
     );
   };
+  /*실종자 리포트 - 메인*/
   const ReportMain = () => {
     return (
       <StReport>
@@ -51,9 +62,10 @@ function MissingPersonReportPage() {
       </StReport>
     );
   };
+  /*실종자 리포트 - 지능형 탐색*/
   const ReportIntelligent = () => {
     return (
-      <StReport>
+      <StReport id="intelligent">
         <Row gutter={[10, 8]} type="flex" style={{ height: "100%" }}>
           <Col span={20} style={{ height: "2%" }}>
             <Typography.Title
@@ -80,6 +92,7 @@ function MissingPersonReportPage() {
       </StReport>
     );
   };
+
   return (
     <StMissingPersonReportPage>
       <ReportMain />

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { Row, Col, Typography } from "antd";
 import { ReconciliationOutlined } from "@ant-design/icons";
-
 import { BasicInfo } from "../components/missingPersonReport/BasicInfo";
 import { StepProgress } from "../components/missingPersonReport/StepProgress";
 import { ReportList } from "../components/missingPersonReport/ReportList";
@@ -11,40 +10,8 @@ import { IntelligentSearchOption } from "../components/reportIntelligent/Intelli
 import { IntelligentBasicInfo } from "../components/reportIntelligent/IntelligentBasicInfo";
 import { IntelligentMap } from "../components/reportIntelligent/IntelligentMap";
 import { IntelligentSearchResult } from "../components/reportIntelligent/IntelligentSearchResult";
-import { useEffect, useRef, useState } from "react";
 
 function MissingPersonReportPage() {
-  const DIVIDER_HEIGHT = 5;
-  const scrollRef = useRef();
-  const [currentPage, setCurrentPage] = useState(1);
-
-  useEffect(() => {
-    const wheelHandler = (e) => {
-      e.preventDefault();
-      const { deltaY } = e;
-      const { scrollTop } = scrollRef.current; // 스크롤 위쪽 끝부분 위치
-      const pageHeight = window.innerHeight; // 화면 세로길이, 100vh와 같습니다.
-
-      if (deltaY > 0) {
-        // 스크롤 내릴 때
-        scrollRef.current?.scrollTo({
-          top: pageHeight * (Math.floor(scrollTop / pageHeight) + 1),
-          behavior: "smooth",
-        });
-      } else {
-        // 스크롤 올릴 때
-        scrollRef.current?.scrollTo({
-          top: pageHeight * (Math.floor(scrollTop / pageHeight) - 1),
-          behavior: "smooth",
-        });
-      }
-    };
-    const scrollRefCurrent = scrollRef.current;
-    scrollRefCurrent.addEventListener("wheel", wheelHandler);
-    return () => {
-      scrollRefCurrent.removeEventListener("wheel", wheelHandler);
-    };
-  }, []);
   const ReportStartBtn = () => {
     return (
       <StReportStartBtn>
@@ -58,8 +25,7 @@ function MissingPersonReportPage() {
   };
   const ReportMain = () => {
     return (
-      <StReportMain>
-        {" "}
+      <StReport>
         <Row gutter={[8, 10]}>
           <Col span={6}>
             <BasicInfo />
@@ -82,12 +48,12 @@ function MissingPersonReportPage() {
             <ReportTabs />
           </Col>
         </Row>
-      </StReportMain>
+      </StReport>
     );
   };
   const ReportIntelligent = () => {
     return (
-      <StReportIntelligent>
+      <StReport>
         <Row gutter={[10, 8]} type="flex" style={{ height: "100%" }}>
           <Col span={20} style={{ height: "2%" }}>
             <Typography.Title
@@ -111,35 +77,12 @@ function MissingPersonReportPage() {
             <IntelligentSearchResult />
           </Col>
         </Row>
-      </StReportIntelligent>
+      </StReport>
     );
   };
   return (
-    <StMissingPersonReportPage ref={scrollRef}>
-      {/* <Row gutter={[8, 10]}>
-        <Col span={6}>
-          <BasicInfo />
-        </Col>
-        <Col span={14}>
-          <ReportMap />
-        </Col>
-        <Col span={4}>
-          <StepProgress />
-        </Col>
-        <Col span={6} md={6}>
-          <Row style={{ marginBottom: 8 }}>
-            <ReportList />
-          </Row>
-          <Row>
-            <ReportStartBtn />
-          </Row>
-        </Col>
-        <Col span={18} md={18}>
-          <ReportTabs />
-        </Col>
-      </Row> */}
+    <StMissingPersonReportPage>
       <ReportMain />
-
       <ReportIntelligent />
     </StMissingPersonReportPage>
   );
@@ -153,6 +96,8 @@ const StMissingPersonReportPage = styled.div`
   overflow-y: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
+  scroll-snap-type: y mandatory;
+  behavior: smooth;
 `;
 const StReportStartBtn = styled.div`
   display: flex;
@@ -179,18 +124,9 @@ const ReportStartBtnLeft = styled.div`
   }
 `;
 
-const StReportMain = styled.div`
+const StReport = styled.div`
   height: 100vh;
   -ms-overflow-style: none;
   scrollbar-width: none;
-`;
-const StReportIntelligent = styled.div`
-  height: 100vh;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`;
-const Divider = styled.div`
-  width: 100%;
-  height: 5px;
-  background-color: gray;
+  scroll-snap-align: center;
 `;

--- a/frontend/src/pages/MissingPersonReportPage.js
+++ b/frontend/src/pages/MissingPersonReportPage.js
@@ -11,8 +11,40 @@ import { IntelligentSearchOption } from "../components/reportIntelligent/Intelli
 import { IntelligentBasicInfo } from "../components/reportIntelligent/IntelligentBasicInfo";
 import { IntelligentMap } from "../components/reportIntelligent/IntelligentMap";
 import { IntelligentSearchResult } from "../components/reportIntelligent/IntelligentSearchResult";
+import { useEffect, useRef, useState } from "react";
 
 function MissingPersonReportPage() {
+  const DIVIDER_HEIGHT = 5;
+  const scrollRef = useRef();
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    const wheelHandler = (e) => {
+      e.preventDefault();
+      const { deltaY } = e;
+      const { scrollTop } = scrollRef.current; // 스크롤 위쪽 끝부분 위치
+      const pageHeight = window.innerHeight; // 화면 세로길이, 100vh와 같습니다.
+
+      if (deltaY > 0) {
+        // 스크롤 내릴 때
+        scrollRef.current?.scrollTo({
+          top: pageHeight * (Math.floor(scrollTop / pageHeight) + 1),
+          behavior: "smooth",
+        });
+      } else {
+        // 스크롤 올릴 때
+        scrollRef.current?.scrollTo({
+          top: pageHeight * (Math.floor(scrollTop / pageHeight) - 1),
+          behavior: "smooth",
+        });
+      }
+    };
+    const scrollRefCurrent = scrollRef.current;
+    scrollRefCurrent.addEventListener("wheel", wheelHandler);
+    return () => {
+      scrollRefCurrent.removeEventListener("wheel", wheelHandler);
+    };
+  }, []);
   const ReportStartBtn = () => {
     return (
       <StReportStartBtn>
@@ -26,33 +58,36 @@ function MissingPersonReportPage() {
   };
   const ReportMain = () => {
     return (
-      <Row gutter={[8, 10]}>
-        <Col span={6}>
-          <BasicInfo />
-        </Col>
-        <Col span={14}>
-          <ReportMap />
-        </Col>
-        <Col span={4}>
-          <StepProgress />
-        </Col>
-        <Col span={6} md={6}>
-          <Row style={{ marginBottom: 8 }}>
-            <ReportList />
-          </Row>
-          <Row>
-            <ReportStartBtn />
-          </Row>
-        </Col>
-        <Col span={18} md={18}>
-          <ReportTabs />
-        </Col>
-      </Row>
+      <StReportMain>
+        {" "}
+        <Row gutter={[8, 10]}>
+          <Col span={6}>
+            <BasicInfo />
+          </Col>
+          <Col span={14}>
+            <ReportMap />
+          </Col>
+          <Col span={4}>
+            <StepProgress />
+          </Col>
+          <Col span={6} md={6}>
+            <Row style={{ marginBottom: 8 }}>
+              <ReportList />
+            </Row>
+            <Row>
+              <ReportStartBtn />
+            </Row>
+          </Col>
+          <Col span={18} md={18}>
+            <ReportTabs />
+          </Col>
+        </Row>
+      </StReportMain>
     );
   };
   const ReportIntelligent = () => {
     return (
-      <>
+      <StReportIntelligent>
         <Row gutter={[10, 8]} type="flex" style={{ height: "100%" }}>
           <Col span={20} style={{ height: "2%" }}>
             <Typography.Title
@@ -76,11 +111,11 @@ function MissingPersonReportPage() {
             <IntelligentSearchResult />
           </Col>
         </Row>
-      </>
+      </StReportIntelligent>
     );
   };
   return (
-    <StMissingPersonReportPage>
+    <StMissingPersonReportPage ref={scrollRef}>
       {/* <Row gutter={[8, 10]}>
         <Col span={6}>
           <BasicInfo />
@@ -103,7 +138,8 @@ function MissingPersonReportPage() {
           <ReportTabs />
         </Col>
       </Row> */}
-      {/* <ReportMain /> */}
+      <ReportMain />
+
       <ReportIntelligent />
     </StMissingPersonReportPage>
   );
@@ -113,8 +149,10 @@ export default MissingPersonReportPage;
 const StMissingPersonReportPage = styled.div`
   padding: 1rem 1rem;
   gap: 1rem;
-  height: 100%;
-  overflow: hidden;
+  height: 100vh;
+  overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 `;
 const StReportStartBtn = styled.div`
   display: flex;
@@ -139,4 +177,20 @@ const ReportStartBtnLeft = styled.div`
     font-size: 1.5rem;
     font-weight: 600;
   }
+`;
+
+const StReportMain = styled.div`
+  height: 100vh;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+const StReportIntelligent = styled.div`
+  height: 100vh;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+const Divider = styled.div`
+  width: 100%;
+  height: 5px;
+  background-color: gray;
 `;


### PR DESCRIPTION
## Describe changes

- 실종자 리포트는 현재 `메인`, `지능형 탐색` 부분으로 나누어져 있음
- 두 화면은 스크롤 및 지능형 탐색 시작하기 버튼 등을 통해 이동 가능
- 각 화면 기준으로 이동 가능한 스크롤 기능 구현

## Issue number or link

- close #104 

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (changes that resolve errors)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Further comments

![ReactApp-Chrome2024-04-1810-24-37-ezgif com-video-to-gif-converter](https://github.com/kookmin-sw/capstone-2024-14/assets/84322890/22502218-1f0a-49b3-8354-5f69807a53fb)

- 살짝 스크롤 하거나 중간에 멈춰도 각 화면 기준으로 스크롤이 이동합니다.
