### PR TITLE
Feat : 실종정보등록 유효성 검사 기능 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "antd": "^5.15.3",
     "axios": "^1.6.8",
     "eslint-config-prettier": "^9.1.0",
+    "moment": "^2.30.1",
     "rc-virtual-list": "^3.11.5",
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.3",

--- a/frontend/src/components/addMisingPerson/GuardianInfo.js
+++ b/frontend/src/components/addMisingPerson/GuardianInfo.js
@@ -33,7 +33,7 @@ export const GuardianInfo = () => {
                 required: true,
               },
             ]}>
-            <RelationInput placeholder="예) 부, 모, 형제, 친구" />
+            <RelationInput placeholder="ex) 부, 모, 형제, 친구" />
           </Form.Item>
         </Col>
         <Col span={7}>
@@ -43,9 +43,12 @@ export const GuardianInfo = () => {
             rules={[
               {
                 required: true,
+                pattern: new RegExp(/^[0-9]{3}-[0-9]{4}-[0-9]{4}$/),
+                message: "'-'를 포함하여 입력해주세요.\nex) '010-1234-5678'",
               },
-            ]}>
-            <ContactInput placeholder="- 없이 숫자만 입력" />
+            ]}
+            style={{ whiteSpace: "pre-wrap" }}>
+            <ContactInput placeholder="ex) 010-1234-5678" />
           </Form.Item>
         </Col>
       </Row>

--- a/frontend/src/components/addMisingPerson/IntelligentSearchInfo.js
+++ b/frontend/src/components/addMisingPerson/IntelligentSearchInfo.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import { Form, DatePicker } from "antd";
 import { SeacrchBox } from "../common/SearchBox";
+import moment from "moment";
+
 const { RangePicker } = DatePicker;
 const config = {
   rules: [
@@ -24,7 +26,13 @@ export const IntelligentSearchInfo = ({ form }) => {
   return (
     <StIntelligentSearchInfo>
       <Form.Item name="searchPeriod" label="탐색 기간" {...rangeConfig}>
-        <RangePicker showTime format="YYYY-MM-DD HH:mm" placeholder={["시작일시", "종료일시"]} />
+        <RangePicker
+          showTime
+          format="YYYY-MM-DD HH:mm"
+          placeholder={["시작일시", "종료일시"]}
+          disabledDate={(d) => !d || d.isAfter(moment())}
+          disabledTime={(d) => !d || d.isAfter(moment())}
+        />
       </Form.Item>
       <Form.Item name="searchLocation" label="탐색 위치" {...config}>
         <SeacrchBox title={"탐색 위치"} form={form} name="searchLocation" />

--- a/frontend/src/components/addMisingPerson/MissingPersonInfo.js
+++ b/frontend/src/components/addMisingPerson/MissingPersonInfo.js
@@ -1,8 +1,8 @@
 import { useState } from "react";
-
 import styled from "styled-components";
 import { Form, Input, DatePicker, TimePicker, Radio, Typography, Row, Col } from "antd";
 import { SeacrchBox } from "../common/SearchBox";
+import moment from "moment";
 
 const options = [
   {
@@ -85,7 +85,13 @@ export const MissingPersonInfo = ({ form }) => {
         </Col>
         <Col span={8}>
           <Form.Item name={["user", "missingTime"]} label="실종일시" {...config}>
-            <DatePicker showTime format="YYYY-MM-DD HH:mm" placeholder="시간 입력" />
+            <DatePicker
+              showTime
+              format="YYYY-MM-DD HH:mm"
+              placeholder="시간 입력"
+              disabledDate={(d) => !d || d.isAfter(moment())}
+              disabledTime={(d) => !d || d.isAfter(moment())}
+            />
           </Form.Item>
         </Col>
         <Col span={13}>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7029,6 +7029,11 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Describe changes

실종정보등록 화면 유효성 검사 기능 추가
- 실종일시 현재 이후 선택 불가
- 전화번호 형식 -> 010-1234-5678
- 탐색 기간 현재 이후 선택 불가

## Issue number or link

- close #155 

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (changes that resolve errors)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Further comments

|실종일시 현재 이후 선택불가|전화번호 유효성 검사|탐색기간 현재 이후 선택불가|
|---|---|---|
|<img src="https://github.com/kookmin-sw/capstone-2024-14/assets/84322890/dec53e9a-6920-48c6-819e-47ad898b3920" width="300">|<img src="https://github.com/kookmin-sw/capstone-2024-14/assets/84322890/a03c2658-37aa-48a1-b3ad-2c6e0439b309" width="300">|<img src="https://github.com/kookmin-sw/capstone-2024-14/assets/84322890/978ab0d4-026c-409a-8fd4-c97cf6c69f79" width="300">|

